### PR TITLE
fix del nil event.

### DIFF
--- a/timer.go
+++ b/timer.go
@@ -171,7 +171,11 @@ func (t *Timer) swapEvent(i, j int) {
 }
 
 // Del is used to remove event from timer.
+// If event is nil, will retrun directly.
 func (t *Timer) Del(event *Event) {
+	if event == nil {
+		return
+	}
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.del(event)

--- a/timer_test.go
+++ b/timer_test.go
@@ -156,6 +156,11 @@ func TestDelInvalidEvent(t *testing.T) {
 	timer.Del(&Event{})
 }
 
+func TestDelNilEvent(t *testing.T) {
+	timer := New()
+	timer.Del(nil)
+}
+
 func TestTimerLoop(t *testing.T) {
 	timer := New()
 	var wg sync.WaitGroup


### PR DESCRIPTION
In old version, del `nil` event will cause panic. In new, if event is
`nil`, will return directly.